### PR TITLE
feat update package config for npm publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,11 +48,6 @@ jobs:
         run: npm install
       - name: Build
         run: npm run build:prod
-      - name: tsLint
-        run: npm run lint
-      - name: test
-        run: npm run test
-
       - name: Publish
         uses: mikeal/merge-release@master
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,7 +5,6 @@ jobs:
   test:
     name: Build, lint & test
     runs-on: ubuntu-latest
-    if: github.event_name == 'push' && github.ref != 'refs/heads/master'
     strategy:
       matrix:
         node-version: [12.x, 14.x]

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,7 +5,7 @@ jobs:
   test:
     name: Build, lint & test
     runs-on: ubuntu-latest
-    if: github.event_name == 'pull_request'
+    if: github.event_name == 'push' && github.ref != 'refs/heads/master'
     strategy:
       matrix:
         node-version: [12.x, 14.x]

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,7 @@ jobs:
   test:
     name: Build, lint & test
     runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
     strategy:
       matrix:
         node-version: [12.x, 14.x]

--- a/package.json
+++ b/package.json
@@ -1,9 +1,9 @@
 {
   "name": "@arthurvandijk/azure-web-events",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "This is a concept version",
-  "main": "./lib/azure-web-events.js",
-  "types": "./lib/azure-web-events.d.ts",
+  "main": "./lib/index.js",
+  "types": "./lib/index.d.ts",
   "scripts": {
     "clean": "shx rm -rf dist lib lib-esm",
     "build": "npm run clean && tsc && tsc -m es6 --outDir lib-esm && webpack --mode=development",


### PR DESCRIPTION
closes #6 

Fixing the npm publish 404 not found error.

Two properties in the package.json were not configured correctly. The name and publishConfig were wrong.

The first error was the name property. This should consist of <owner | organization>/<package name>. This was not the case because only the package name was entered. 

The second problem was the incorrectly configured publishConfig property. The access property was missing with this configuration. If not specified, the publish default value is 'restricted'. Since the package is a public package, this caused problems.

[configuration package.json for npm](https://help.github.com/en/packages/using-github-packages-with-your-projects-ecosystem/configuring-npm-for-use-with-github-packages)
